### PR TITLE
chore: reduce Nuxt build time and image size by ~50%

### DIFF
--- a/nuxt/Dockerfile
+++ b/nuxt/Dockerfile
@@ -2,24 +2,20 @@ FROM --platform=linux/arm64 oven/bun:1 AS base
 WORKDIR /usr/src/app
 
 FROM base AS install
-RUN mkdir -p /temp/dev
-COPY package.json bun.lockb /temp/dev/
-RUN cd /temp/dev && bun install
 
 RUN mkdir -p /temp/prod
 COPY package.json bun.lockb /temp/prod/
 RUN cd /temp/prod && bun install --production
 
-FROM base AS prerelease
-COPY --from=install /temp/dev/node_modules node_modules
+FROM base AS build
+COPY --from=install /temp/prod/node_modules node_modules
 COPY . .
 
 ENV NODE_ENV=production
 RUN bun run build
 
 FROM base AS release
-COPY --from=install /temp/prod/node_modules node_modules
-COPY --from=prerelease /usr/src/app/.output/ .output/
+COPY --from=build /usr/src/app/.output/ .output/
 
 USER bun
 EXPOSE 3000/tcp


### PR DESCRIPTION
The Nuxt build output has no reliance on the `node_modules` after build (390MB -> 215MB). This avoids copying it to the final Docker image and also reduces build times by skipping the dev/prerelease step since at the moment this repo is only used to build and push to production.

> This could change a bit if e.g. a dockerized local workflow is introduced with e.g. compose